### PR TITLE
ci: refactor integration test workflow to use repository variable

### DIFF
--- a/.github/workflows/main-validation.yml
+++ b/.github/workflows/main-validation.yml
@@ -186,32 +186,20 @@ jobs:
   # ---------------------------------------------------------------
   # Stage 5: Integration tests (requires AWS credentials)
   #
-  # This job is gated: it only runs when credentials are available.
-  # Without creds, it skips gracefully — the pipeline still passes.
+  # Gated by the repository variable ENABLE_INTEGRATION_TESTS.
+  # Set it to "true" in Settings > Variables > Actions to enable.
+  # Without it, this entire section is skipped at the workflow level
+  # — no runners are provisioned, no billing is incurred.
+  #
+  # Can also be triggered on-demand via workflow_dispatch.
   # ---------------------------------------------------------------
-  check-credentials:
-    name: Check AWS Credentials
-    runs-on: ubuntu-latest
-    needs: [validate, test-compile]
-    outputs:
-      has_creds: ${{ steps.check.outputs.has_creds }}
-    steps:
-      - name: Check for AWS credentials
-        id: check
-        run: |
-          if [[ -n "${{ secrets.AWS_ACCESS_KEY_ID }}" && -n "${{ secrets.AWS_SECRET_ACCESS_KEY }}" ]]; then
-            echo "has_creds=true" >> "$GITHUB_OUTPUT"
-            echo "AWS credentials found. Integration tests will run."
-          else
-            echo "has_creds=false" >> "$GITHUB_OUTPUT"
-            echo "No AWS credentials configured. Integration tests will be skipped."
-          fi
-
   integration-test:
     name: Integration Test (${{ matrix.test }})
     runs-on: ubuntu-latest
-    needs: [check-credentials]
-    if: needs.check-credentials.outputs.has_creds == 'true' || (github.event_name == 'workflow_dispatch' && github.event.inputs.run_integration_tests == 'true')
+    needs: [validate, test-compile]
+    if: |
+      (vars.ENABLE_INTEGRATION_TESTS == 'true') ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.run_integration_tests == 'true')
     timeout-minutes: 45
 
     strategy:


### PR DESCRIPTION
Updated the integration test job in the GitHub Actions workflow to be gated by the repository variable ENABLE_INTEGRATION_TESTS. This change allows for better control over when integration tests are executed, ensuring that no resources are provisioned if the variable is not set to "true". The previous check for AWS credentials has been removed, streamlining the workflow.